### PR TITLE
Update Min version to 12; Replace unmaintained actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,30 +12,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        # https://github.com/marketplace/actions/checkout
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v4
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Zip files
         run: |
           zip -r ${{ steps.get_version.outputs.VERSION }}.zip *.css module.json LICENSE scripts templates assets lang
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Create and Upload Release
+        # https://github.com/marketplace/actions/gh-release
+        # https://github.com/softprops/action-gh-release
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.get_version.outputs.VERSION }}.zip
-          asset_name: ${{ steps.get_version.outputs.VERSION }}.zip
-          asset_content_type: application/zip
+          files: ${{ steps.get_version.outputs.VERSION }}.zip
+
+      # - name: Create Release
+      #   id: create_release
+      #   # https://github.com/actions/create-release
+      #   # unmaintained
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ github.ref }}
+      #     release_name: Release ${{ github.ref }}
+      #     draft: false
+      #     prerelease: false
+      # - name: Upload Release Asset
+      #   id: upload-release-asset
+      #   # https://github.com/actions/upload-release-asset
+      #   # unmaintained
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: ./${{ steps.get_version.outputs.VERSION }}.zip
+      #     asset_name: ${{ steps.get_version.outputs.VERSION }}.zip
+      #     asset_content_type: application/zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.22.1
+- Supporting v12 required removing v11 support.
+
 # v2.22.0
 - Updated to support Foundry v12
    - NOTE: Due to V12 no longer supporing synchronous dice rolling HP are now set post token creation. That means you'll see the HP change displayed briefly (a small number with the delta will float over the token for a moment).

--- a/module.json
+++ b/module.json
@@ -16,9 +16,9 @@
   ],
   "url": "https://github.com/Moerill/token-mold",
   "bugs": "https://github.com/Moerill/token-mold/issues",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "compatibility": {
-    "minimum": "11",
+    "minimum": "12",
     "verified": "12",
     "maximum": "12"
   },
@@ -68,5 +68,5 @@
   ],
   "socket": false,
   "manifest": "https://raw.githubusercontent.com/BeardedGnome/token-mold/master/module.json",
-  "download": "https://github.com/BeardedGnome/token-mold/releases/download/v2.22.0/v2.22.0.zip"
+  "download": "https://github.com/BeardedGnome/token-mold/releases/download/v2.22.1/v2.22.1.zip"
 }


### PR DESCRIPTION
Supporting v12 requires an API that isn't available in v11.

Also, updated the actions in the publish script to a supported version.